### PR TITLE
Adjust carousel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,7 +26,7 @@ body {
     height: 60px;
     margin-right: 25px;
 }
-  
+
 .c-header h1{
     position: relative;
     text-align: center;
@@ -103,7 +103,9 @@ body {
     margin-left: auto;
     margin-right: auto;
     margin-bottom: 0.25rem;
-
+}
+.thumb::selection {
+    background-color: transparent;
 }
 .thumb .type {
     display:none;
@@ -506,7 +508,7 @@ body {
     margin-top: 1rem;
 }
 
-.modal-content{ 
+.modal-content{
     background-color: white;
 }
 
@@ -532,4 +534,21 @@ body {
     .alert {
         margin-top: 0.5rem;
     }
+}
+
+
+/* ******************* */
+/* EFFECTS             */
+/* ******************* */
+
+img.lcarousel {
+    z-index: 10;
+    left: -20%;
+    opacity: 0;
+    transition: all 1s;
+}
+img.lcarousel.current {
+    z-index: 20;
+    left: 0;
+    opacity: 1;
 }

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 
 		<link rel="stylesheet" type="text/css" href="css/style.css">
 		<link rel="stylesheet" type="text/css" href="css/theme.css">
-		<script type="text/javascript" src="js/theme.js"></script>
+		<script type="text/javascript" src="js/extra.js"></script>
 
    	<link rel="icon" href="imgs/favicon.png">
 	</head>

--- a/js/app.js
+++ b/js/app.js
@@ -361,6 +361,7 @@ var vm = new Vue({
             this.thumbChangeCount += 1;
             if (changeThumbs) {
                 this.thumbChangeCount = 0;
+                lcarousel.cycleAll();
             }
 
             for (c = 0; c < data.length; c++) { // Check each column
@@ -371,7 +372,7 @@ var vm = new Vue({
                     if (ev.type == "DailyQuest") {
                         this.updateDailyQuest(ev, now, nowMoment, localZone);
                     } else {
-                        this.updateEventGroup(ev, now, changeThumbs);
+                        this.updateEventGroup(ev, now, changeThumbs, false);
                     }
 
                 }
@@ -380,9 +381,9 @@ var vm = new Vue({
             }
         },
 
-        updateClick: function(ev) {
+        updateClick: function(ev, e) {
             var nowMoment = moment.tz("Asia/Tokyo");
-            this.updateEventGroup(ev, nowMoment._d.getTime(), true);
+            this.updateEventGroup(ev, nowMoment._d.getTime(), true, e.target);
         },
 
         updateDailyQuest: function(ev, now, nowMoment, localZone) {
@@ -396,7 +397,7 @@ var vm = new Vue({
             ev.japanend = deadline.format("MMM Do, H:mm");
             ev.localend = deadline.clone().tz(localZone).format("MMM Do, H:mm");
         },
-        updateEventGroup: function(ev, now, changeThumbs) {
+        updateEventGroup: function(ev, now, changeThumbs, elem) {
             let allExpired = true,
                 nextDate = Infinity,
                 nextType = "finished",
@@ -436,6 +437,9 @@ var vm = new Vue({
                     ev.imageStep = 0;
                 }
                 ev.image = ev.imageList[ev.imageStep];
+                if (elem) {
+                    lcarousel.cycle(elem.parentNode ?? elem);
+                }
             }
 
             // Check if event should be visible

--- a/js/components.js
+++ b/js/components.js
@@ -191,10 +191,8 @@ Vue.component("bar-mark", {
 
 Vue.component("ev-thumb", {
     props: ["ev"],
-    template: `<div class='thumb' :class='{ bn : filter(ev) }' v-on:click="vm.updateClick(ev)"">
-        <transition name='thumb-change'>
-            <img :src='ev.image' :key='ev.image' class='img-fluid'>
-        </transition>
+    template: `<div class='thumb lcarousel' :class='{ bn : filter(ev) }' v-on:click='vm.updateClick(ev, $event)'>
+        <img v-for='src in ev.imageList' v-bind:src='src' class='img-fluid lcarousel'></img>
         <div class='type'>
             <span>{{ ev.type | typeName }}</span>
         </div>

--- a/js/extra.js
+++ b/js/extra.js
@@ -19,7 +19,33 @@ const theme = {
 		document.cookie = "theme="+name+"; path=/; max-age=436320000; secure; samesite=lax";
 		return true;
 	}
-}
+};
+
+const lcarousel = {
+	name: 'lcarousel',
+	init: function() {
+		document.querySelectorAll("div."+lcarousel.name+" > img."+lcarousel.name+":first-of-type").forEach((el) => {
+			el.classList.add('current');
+		});
+		return true;
+	},
+	cycle: function(wrapper) {
+		const current = wrapper.querySelector("img.lcarousel.current");
+		current.classList.remove('current');
+		if (current.nextElementSibling && current.nextElementSibling.classList.contains('lcarousel'))
+			current.nextElementSibling.classList.add('current');
+		else
+			wrapper.querySelector("img.lcarousel:first-of-type").classList.add('current');
+		return true;
+	},
+	cycleAll: function() {
+		document.querySelectorAll("div."+lcarousel.name).forEach((el) => {
+			if (el.querySelectorAll("img."+lcarousel.name).length > 1)
+				lcarousel.cycle(el);
+		});
+		return true;
+	}
+};
 
 document.addEventListener("DOMContentLoaded", function() {
 	theme.set(theme.get());
@@ -28,5 +54,7 @@ document.addEventListener("DOMContentLoaded", function() {
 		$switcher.addEventListener("change", (event) => {
 			theme.set(event.target.value);
 		});
+
+	lcarousel.init();
 });
 

--- a/js/extra.js
+++ b/js/extra.js
@@ -15,32 +15,36 @@ const theme = {
 		if (old_name)
 			document.body.classList.remove("theme-"+old_name);
 		document.body.setAttribute("data-theme", name);
-		document.body.classList.add('theme-'+name);
+		document.body.classList.add("theme-"+name);
 		document.cookie = "theme="+name+"; path=/; max-age=436320000; secure; samesite=lax";
 		return true;
 	}
 };
 
+// e.g.: <div class="lcarousel"><img class="lcarousel current" /><img class="lcarousel" /></div>
 const lcarousel = {
-	name: 'lcarousel',
+	name: "lcarousel",
+	cursor: "current",
+	wrapTag: "div",
+	itemTag: "img",
 	init: function() {
-		document.querySelectorAll("div."+lcarousel.name+" > img."+lcarousel.name+":first-of-type").forEach((el) => {
-			el.classList.add('current');
+		document.querySelectorAll(lcarousel.wrapTag+"."+lcarousel.name+" > "+lcarousel.itemTag+"."+lcarousel.name+":first-of-type").forEach((el) => {
+			el.classList.add(lcarousel.cursor);
 		});
 		return true;
 	},
-	cycle: function(wrapper) {
-		const current = wrapper.querySelector("img.lcarousel.current");
-		current.classList.remove('current');
-		if (current.nextElementSibling && current.nextElementSibling.classList.contains('lcarousel'))
-			current.nextElementSibling.classList.add('current');
+	cycle: function($wrapper) {
+		const $current = $wrapper.querySelector(lcarousel.itemTag+"."+lcarousel.name+"."+lcarousel.cursor);
+		$current.classList.remove(lcarousel.cursor);
+		if ($current.nextElementSibling && $current.nextElementSibling.classList.contains(lcarousel.name))
+			$current.nextElementSibling.classList.add(lcarousel.cursor);
 		else
-			wrapper.querySelector("img.lcarousel:first-of-type").classList.add('current');
+			$wrapper.querySelector(lcarousel.itemTag+"."+lcarousel.name+":first-of-type").classList.add(lcarousel.cursor);
 		return true;
 	},
 	cycleAll: function() {
-		document.querySelectorAll("div."+lcarousel.name).forEach((el) => {
-			if (el.querySelectorAll("img."+lcarousel.name).length > 1)
+		document.querySelectorAll(lcarousel.wrapTag+"."+lcarousel.name).forEach((el) => {
+			if (el.querySelectorAll(lcarousel.itemTag+"."+lcarousel.name).length > 1)
 				lcarousel.cycle(el);
 		});
 		return true;


### PR DESCRIPTION
**Do not merge if you want everything to be handled by Vue.js**

### Issue
Cycling event images by removing old `<img>` and creating new one forces browser to request the image again.
Tested on Chromium v91.
Request headers have `cache-control: no-cache; pragma: no-cache`, there's no `If-None-Match`, etc.
Image body is actually transferred on each cycle.
So it causes unneeded network traffic, extra load on rika.ren, and significant (about ~300MB just in a few hours) memory leak.

### Solution
Load all images and hide the extra `<img>` elements instead of deleting.

### Proposed code
I'm totes unfamiliar with Vue.js so here goes vanilla js implementation.
Demo: https://LiviaMedeiros.github.io/Kamihama-Clock-Tower/
Feel free to either merge it or adapt into pure Vue.js if it's possible.