### PR TITLE
Hide tz selector on UTC+9

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,7 @@
 body {
     background-color: #ececec;
-    overflow: scroll;
+    overflow-y: scroll;
+    padding-bottom: 64px;
 }
 
 .timer-number {

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 			</div>
 
 			
-			<div class="btn-group btn-group-toggle time-buttons fixed">
+			<div v-if="new Date().getTimezoneOffset() !== -540" class="btn-group btn-group-toggle time-buttons fixed">
 				<label class="btn btn-primary btn-sm" :class="{active: currentZone == 'japan' }" id="japan-time">
 					<input type="radio" name="options" value="japan" v-model="currentZone" @change="changeTimezone" > <h5>Use Server Time</h5>
 					<span v-text="japanTime"></span>
@@ -100,8 +100,5 @@
 			
 			//document.getElementById("days");
 		</script>
-		
-	<br/><br/><br/>
-		
 	</body>
 </html>


### PR DESCRIPTION
Slight cleanup of bottom zone of page. Timezone selector looks confusing if user's timezone matches magireco's, perhaps is makes sense to show it only when there actually is a choice.